### PR TITLE
Import from Featurevisor SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "featurevisor-example-nodejs",
+  "private": true,
   "version": "1.0.0",
-  "description": "",
+  "description": "Example Node.js app using Featurevisor SDK",
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "featurevisor-example-nodejs",
   "private": true,
+  "type": "module",
   "version": "1.0.0",
   "description": "Example Node.js app using Featurevisor SDK",
   "main": "index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,23 @@
-import FeaturevisorSDK from "@featurevisor/sdk";
+/**
+ * Import Featurevisor SDK
+ */
 
+// If you are using `.mjs` files or have `type: module` in your `package.json`, you can use `import` syntax.
+import FeaturevisorSDK from "@featurevisor/sdk";
 const { createInstance } = FeaturevisorSDK;
 
+// otherwise, use `require` syntax
+// const { createInstance } = require("@featurevisor/sdk");
+
+/**
+ * Constants
+ */
 const DATAFILE_URL =
   "https://featurevisor-example-cloudflare.pages.dev/production/datafile-tag-all.json";
 
+/**
+ * Main
+ */
 async function main() {
   const f = createInstance({
     datafileUrl: DATAFILE_URL,

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-// import { createInstance } from "@featurevisor/sdk";
-const { createInstance } = require("@featurevisor/sdk");
+import { createInstance } from "@featurevisor/sdk";
 
 const DATAFILE_URL =
   "https://featurevisor-example-cloudflare.pages.dev/production/datafile-tag-all.json";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
-import { createInstance } from "@featurevisor/sdk";
+import FeaturevisorSDK from "@featurevisor/sdk";
+
+const { createInstance } = FeaturevisorSDK;
 
 const DATAFILE_URL =
   "https://featurevisor-example-cloudflare.pages.dev/production/datafile-tag-all.json";


### PR DESCRIPTION
## What's happening here?

Trying to figure out how to make this work in Node.js apps natively (v20+) without requiring any additional compiling/transpiling/bundling:

```js
import { createInstance } from "@featurevisor/sdk";
```

## What solutions are available?

### 1: Use `require`

```js
const { createInstance } = require("@featurevisor/sdk";
```

### 2: If using module type, then import and destruct

If you are either using `.mjs` files or using `"type": "module"` in your application's `package.json` file, then do:

```js
import FeaturevisorSDK from "@featurevisor/sdk";

const { createInstance } = FeaturevisorSDK;
```

## What issues have been discovered?

See GitHub Actions output for each commit in this PR for more details.

### 1: When importing directly without any further changes

```
$ node ./src/index.js
(node:1781) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
/home/runner/work/featurevisor-example-nodejs/featurevisor-example-nodejs/src/index.js:1
import { createInstance } from "@featurevisor/sdk";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at internalCompileFunction (node:internal/vm:77:18)
    at wrapSafe (node:internal/modules/cjs/loader:1288:20)
    at Module._compile (node:internal/modules/cjs/loader:1340:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:143[5](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397348433/job/23000503564#step:5:6):10)
    at Module.load (node:internal/modules/cjs/loader:120[7](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397348433/job/23000503564#step:5:8):32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:2[8](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397348433/job/23000503564#step:5:9):4[9](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397348433/job/23000503564#step:5:10)

Node.js v20.11.1
```

### 2: When `type: "module"` is added to `package.json`

```
$ node ./src/index.js
file:///home/runner/work/featurevisor-example-nodejs/featurevisor-example-nodejs/src/index.js:1
import { createInstance } from "@featurevisor/sdk";
         ^^^^^^^^^^^^^^
SyntaxError: Named export 'createInstance' not found. The requested module '@featurevisor/sdk' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:
import pkg from '@featurevisor/sdk';
const { createInstance } = pkg;
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:132:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:214:[5](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397410162/job/23000669991#step:5:6))
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)
    at async loadESM (node:internal/process/esm_loader:28:[7](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397410162/job/23000669991#step:5:8))
    at async handleMainPromise (node:internal/modules/run_main:[11](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397410162/job/23000669991#step:5:12)3:[12](https://github.com/featurevisor/featurevisor-example-nodejs/actions/runs/8397410162/job/23000669991#step:5:13))
Node.js v20.11.1
```
